### PR TITLE
Fix buffered handler

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -217,10 +217,12 @@ func (h bufferedHandler) run() {
 // writes happen asynchronously, all writes to a BufferedHandler
 // never return an error and any errors from the wrapped handler are ignored.
 func BufferedHandler(bufSize int, h Handler) Handler {
-	return &bufferedHandler{
+	handler := &bufferedHandler{
 		handler: h,
 		recs:    make(chan *Record, bufSize),
 	}
+	go handler.run()
+	return handler
 }
 
 // swapHandler wraps another handler that may swapped out

--- a/log15_test.go
+++ b/log15_test.go
@@ -139,6 +139,26 @@ func TestMultiHandler(t *testing.T) {
 
 }
 
+type waitHandler struct {
+	ch chan Record
+}
+
+func (h *waitHandler) Log(r *Record) error {
+	h.ch <- *r
+	return nil
+}
+
+func TestBufferedHandler(t *testing.T) {
+	ch := make(chan Record)
+	l := New()
+	l.SetHandler(BufferedHandler(0, &waitHandler{ch}))
+
+	l.Debug("buffer")
+	if r := <-ch; r.Msg != "buffer" {
+		t.Fatalf("wrong value for r.Msg. Got %s expected %s", r.Msg, "")
+	}
+}
+
 func TestLogContext(t *testing.T) {
 	l, r := testLogger()
 	l = l.New("foo", "bar")


### PR DESCRIPTION
No one was calling bufferedHandler.run, causing no log output and eventually
deadlock.
