### PR TITLE
Fix versioned import paths.

### DIFF
--- a/ext/error.go
+++ b/ext/error.go
@@ -1,6 +1,6 @@
 package ext
 
-import log "github.com/inconshreveable/log15"
+import log "gopkg.in/inconshreveable/log15.v1"
 
 // ErrorHandler wraps another handler and passes all records through
 // unchanged except if the logged context contains a non-nil error

--- a/root.go
+++ b/root.go
@@ -1,7 +1,7 @@
 package log15
 
 import (
-	"github.com/inconshreveable/log15/term"
+	"gopkg.in/inconshreveable/log15.v1/term"
 	"os"
 )
 


### PR DESCRIPTION
Hi,

  I've seen on the mailing list that you added the gopkg.in [import path](http://gopkg.in/inconshreveable/log15.v1). There's however a small issue that the internal import paths are still pointing to github.

Specifically:
- root.go -> import "github.com/inconshreveable/log15/term"
- ext/error.go -> import "github.com/inconshreveable/log15"

This leads to double "go get"-s. Importing from gopkg in will pull in the versioned paths, but since those reference the unversioned ones, those too will get pulled in. This will potentially cause two versions of the package to be present simultaneously, and even used half/half mixed.

I've fixed the import paths to use gopkg.in internally too.

Cheers,
  Peter
