### PR TITLE
Fix compile error

### DIFF
--- a/ext/handler.go
+++ b/ext/handler.go
@@ -34,7 +34,7 @@ func EscalateErrHandler(h log.Handler) log.Handler {
 				}
 			}
 		}
-	}
+	})
 
 	return h.Log(r)
 }


### PR DESCRIPTION
Unterminated ( caused:

```
handler.go:37:3: missing ',' before newline in argument list
handler.go:39:2: expected operand, found 'return'
```
