### PR TITLE
Fix race in ext.RandId

### DIFF
--- a/ext/id.go
+++ b/ext/id.go
@@ -3,14 +3,11 @@ package ext
 import (
 	"fmt"
 	"math/rand"
+	"sync"
 	"time"
 )
 
-var r *rand.Rand
-
-func init() {
-	r = rand.New(rand.NewSource(time.Now().Unix()))
-}
+var r = rand.New(&lockedSource{src: rand.NewSource(time.Now().Unix())})
 
 // RandId creates a random identifier of the requested length.
 // Useful for assigning mostly-unique identifiers for logging
@@ -27,4 +24,24 @@ func RandId(idlen int) string {
 		b[i] = byte((randVal >> (8 * uint(byteIdx))) & 0xFF)
 	}
 	return fmt.Sprintf("%x", b)
+}
+
+// lockedSource is a wrapper to allow a rand.Source to be used
+// concurrently (same type as the one used internally in math/rand).
+type lockedSource struct {
+	lk  sync.Mutex
+	src rand.Source
+}
+
+func (r *lockedSource) Int63() (n int64) {
+	r.lk.Lock()
+	n = r.src.Int63()
+	r.lk.Unlock()
+	return
+}
+
+func (r *lockedSource) Seed(seed int64) {
+	r.lk.Lock()
+	r.src.Seed(seed)
+	r.lk.Unlock()
 }


### PR DESCRIPTION
The *rand.Rand source was not protected against concurrent access.
