### PR TITLE
Implement the suggestions that fixes #4

### DIFF
--- a/format.go
+++ b/format.go
@@ -84,7 +84,7 @@ func TerminalFormat() Format {
 //
 func LogfmtFormat() Format {
 	return FormatFunc(func(r *Record) []byte {
-		common := []interface{}{"t", r.Time, "lvl", r.Lvl, "msg", r.Msg}
+		common := []interface{}{r.KeyNames.Time, r.Time, r.KeyNames.Lvl, r.Lvl, r.KeyNames.Msg, r.Msg}
 		buf := &bytes.Buffer{}
 		logfmt(buf, append(common, r.Ctx...), 0)
 		return buf.Bytes()
@@ -134,9 +134,9 @@ func JsonFormatEx(pretty, lineSeparated bool) Format {
 	return FormatFunc(func(r *Record) []byte {
 		props := make(map[string]interface{})
 
-		props["t"] = r.Time
-		props["lvl"] = r.Lvl
-		props["msg"] = r.Msg
+		props[r.KeyNames.Time] = r.Time
+		props[r.KeyNames.Lvl] = r.Lvl
+		props[r.KeyNames.Msg] = r.Msg
 
 		for i := 0; i < len(r.Ctx); i += 2 {
 			k, ok := r.Ctx[i].(string)

--- a/handler.go
+++ b/handler.go
@@ -123,11 +123,11 @@ func FilterHandler(fn func(r *Record) bool, h Handler) Handler {
 func MatchFilterHandler(key string, value interface{}, h Handler) Handler {
 	return FilterHandler(func(r *Record) (pass bool) {
 		switch key {
-		case "lvl":
+		case r.KeyNames.Lvl:
 			return r.Lvl == value
-		case "t":
+		case r.KeyNames.Time:
 			return r.Time == value
-		case "msg":
+		case r.KeyNames.Msg:
 			return r.Msg == value
 		}
 

--- a/logger.go
+++ b/logger.go
@@ -5,7 +5,9 @@ import (
 	"time"
 )
 
+const timeKey = "t"
 const lvlKey = "lvl"
+const msgKey = "msg"
 const errorKey = "LOG15_ERROR"
 
 type Lvl int
@@ -57,10 +59,17 @@ func LvlFromString(lvlString string) (Lvl, error) {
 
 // A Record is what a Logger asks its handler to write
 type Record struct {
-	Time time.Time
-	Lvl  Lvl
+	Time     time.Time
+	Lvl      Lvl
+	Msg      string
+	Ctx      []interface{}
+	KeyNames RecordKeyNames
+}
+
+type RecordKeyNames struct {
+	Time string
 	Msg  string
-	Ctx  []interface{}
+	Lvl  string
 }
 
 // A Logger writes key/value pairs to a Handler
@@ -90,6 +99,11 @@ func (l *logger) write(msg string, lvl Lvl, ctx []interface{}) {
 		Lvl:  lvl,
 		Msg:  msg,
 		Ctx:  append(l.ctx, normalize(ctx)...),
+		KeyNames: RecordKeyNames{
+			Time: timeKey,
+			Msg:  msgKey,
+			Lvl:  lvlKey,
+		},
 	})
 }
 


### PR DESCRIPTION
I went through the code and implemented the changes that fixes #4.  I ended up making a second structure for the KeyNames so as to make initialization of the record easier.  This update allows someone to write a handler such as:

```
func MyLogFmtHandler(h log.Handler) log.Handler {
    return log.FuncHandler(func(r *log.Record) error {
        r.KeyNames.Msg = "log_message"
        r.KeyNames.Lvl = "log_level"
        r.KeyNames.Time = "log_timestamp"

        return h.Log(r)
    })
}
```

and then invoke it by doing something like:

```
logger.SetHandler(MyLogFmtHandler(log.StreamHandler(os.Stdout, log.LogfmtFormat())))
```

I did some benchmarking on this new version versus the old version.  I found that the `BenchmarkJsonNoCtx` benchmark got significantly faster:  4754 ns/op --> 1616 ns/op.

```
PASS
BenchmarkStreamNoCtx         500000  3856 ns/op
BenchmarkDiscard           10000000   170 ns/op
BenchmarkLinenum            2000000   782 ns/op
BenchmarkLogfmtNoCtx         500000  3530 ns/op
BenchmarkJsonNoCtx           500000  4754 ns/op
BenchmarkMultiLevelFilter  10000000   198 ns/op
ok      github.com/inconshreveable/log15    12.641s
```

versus

```
PASS
BenchmarkStreamNoCtx         500000  3835 ns/op
BenchmarkDiscard           10000000   193 ns/op
BenchmarkLinenum            2000000   803 ns/op
BenchmarkLogfmtNoCtx         500000  3525 ns/op
BenchmarkJsonNoCtx          1000000  1616 ns/op
BenchmarkMultiLevelFilter  10000000   220 ns/op
ok      github.com/gtrevg/log15 12.375s
```
