### PR TITLE
Add support for running on AppEngine.

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -8,8 +8,6 @@ import (
 	"os"
 	"reflect"
 	"sync"
-	"sync/atomic"
-	"unsafe"
 
 	"github.com/inconshreveable/log15/stack"
 )
@@ -277,20 +275,6 @@ func BufferedHandler(bufSize int, h Handler) Handler {
 		}
 	}()
 	return ChannelHandler(recs)
-}
-
-// swapHandler wraps another handler that may be swapped out
-// dynamically at runtime in a thread-safe fashion.
-type swapHandler struct {
-	handler unsafe.Pointer
-}
-
-func (h *swapHandler) Log(r *Record) error {
-	return (*(*Handler)(atomic.LoadPointer(&h.handler))).Log(r)
-}
-
-func (h *swapHandler) Swap(newHandler Handler) {
-	atomic.StorePointer(&h.handler, unsafe.Pointer(&newHandler))
 }
 
 // LazyHandler writes all values to the wrapped handler after evaluating

--- a/handler_appengine.go
+++ b/handler_appengine.go
@@ -1,0 +1,26 @@
+// +build appengine
+
+package log15
+
+import "sync"
+
+// swapHandler wraps another handler that may be swapped out
+// dynamically at runtime in a thread-safe fashion.
+type swapHandler struct {
+	handler interface{}
+	lock    sync.RWMutex
+}
+
+func (h *swapHandler) Log(r *Record) error {
+	h.lock.RLock()
+	defer h.lock.RUnlock()
+
+	return h.handler.(Handler).Log(r)
+}
+
+func (h *swapHandler) Swap(newHandler Handler) {
+	h.lock.Lock()
+	defer h.lock.Unlock()
+
+	h.handler = newHandler
+}

--- a/handler_other.go
+++ b/handler_other.go
@@ -1,0 +1,22 @@
+// +build !appengine
+
+package log15
+
+import (
+	"sync/atomic"
+	"unsafe"
+)
+
+// swapHandler wraps another handler that may be swapped out
+// dynamically at runtime in a thread-safe fashion.
+type swapHandler struct {
+	handler unsafe.Pointer
+}
+
+func (h *swapHandler) Log(r *Record) error {
+	return (*(*Handler)(atomic.LoadPointer(&h.handler))).Log(r)
+}
+
+func (h *swapHandler) Swap(newHandler Handler) {
+	atomic.StorePointer(&h.handler, unsafe.Pointer(&newHandler))
+}

--- a/stack/stack_pool_chan.go
+++ b/stack/stack_pool_chan.go
@@ -1,4 +1,4 @@
-// +build !go1.3
+// +build !go1.3 appengine
 
 package stack
 

--- a/term/terminal_appengine.go
+++ b/term/terminal_appengine.go
@@ -3,12 +3,11 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !appengine
+// +build appengine
 
 package term
 
-import "syscall"
-
-const ioctlReadTermios = syscall.TCGETS
-
-type Termios syscall.Termios
+// IsTty always returns false on AppEngine.
+func IsTty(fd uintptr) bool {
+	return false
+}


### PR DESCRIPTION
A few packages are disabled on appengine. Notably: syscall and unsafe.

This fix extracts the code snippets dependent on those few particular imports and provides an alternate implementation to them. Additionally, the terminal check is implemented by simply returning false, as appengine will never have a color codable interactive terminal.

A simple snippet running on GAE:
```go
package appengine

import (
	"bytes"
	"fmt"
	"net/http"

	"github.com/inconshreveable/log15"
)

func init() {
	http.HandleFunc("/log", LogTest)
}

func LogTest(w http.ResponseWriter, r *http.Request) {
	buf := new(bytes.Buffer)
	log15.Root().SetHandler(log15.StreamHandler(buf, log15.LogfmtFormat()))
	log15.Info("Test log")
	fmt.Fprintf(w, "Log:<br>%s", string(buf.Bytes()))
}
```

And the output as expected:
```
Log:
t=2015-01-04T18:36:33+0000 lvl=info msg="Test log"
```
