### PR TITLE
Use atomic.Value instead of unsafe pointer swapping

### DIFF
--- a/handler_go14.go
+++ b/handler_go14.go
@@ -1,27 +1,19 @@
-// +build appengine
-// +build !go1.4
+// +build go1.4
 
 package log15
 
-import "sync"
+import "sync/atomic"
 
 // swapHandler wraps another handler that may be swapped out
 // dynamically at runtime in a thread-safe fashion.
 type swapHandler struct {
-	handler interface{}
-	lock    sync.RWMutex
+	handler atomic.Value
 }
 
 func (h *swapHandler) Log(r *Record) error {
-	h.lock.RLock()
-	defer h.lock.RUnlock()
-
-	return h.handler.(Handler).Log(r)
+	return (*h.handler.Load().(*Handler)).Log(r)
 }
 
 func (h *swapHandler) Swap(newHandler Handler) {
-	h.lock.Lock()
-	defer h.lock.Unlock()
-
-	h.handler = newHandler
+	h.handler.Store(&newHandler)
 }

--- a/handler_other.go
+++ b/handler_other.go
@@ -1,4 +1,5 @@
 // +build !appengine
+// +build !go1.4
 
 package log15
 


### PR DESCRIPTION
I *think* this will work on AppEngine, but I don't have an account to test it out. @karalabe any chance you can verify this?