### PR TITLE
Adding the support of syslog.Priority to the syslog handler

### DIFF
--- a/syslog.go
+++ b/syslog.go
@@ -14,10 +14,24 @@ func SyslogHandler(tag string, fmtr Format) (Handler, error) {
 	return sharedSyslog(fmtr, wr, err)
 }
 
+// SyslogHandlerPriority opens a connection to the system syslog daemon by calling
+// syslog.New and writes all records to it. Supports the priority concept.
+func SyslogHandlerPriority(p syslog.Priority, tag string, fmtr Format) (Handler, error) {
+	wr, err := syslog.New(p, tag)
+	return sharedSyslog(fmtr, wr, err)
+}
+
 // SyslogHandler opens a connection to a log daemon over the network and writes
 // all log records to it.
 func SyslogNetHandler(net, addr string, tag string, fmtr Format) (Handler, error) {
 	wr, err := syslog.Dial(net, addr, syslog.LOG_INFO, tag)
+	return sharedSyslog(fmtr, wr, err)
+}
+
+// SyslogHandler opens a connection to a log daemon over the network and writes
+// all log records to it. Supports the priority concept.
+func SyslogNetHandlerPriority(net, addr string, tag string, p syslog.Priority, fmtr Format) (Handler, error) {
+	wr, err := syslog.Dial(net, addr, p, tag)
 	return sharedSyslog(fmtr, wr, err)
 }
 

--- a/syslog.go
+++ b/syslog.go
@@ -67,3 +67,11 @@ func (m muster) SyslogHandler(tag string, fmtr Format) Handler {
 func (m muster) SyslogNetHandler(net, addr string, tag string, fmtr Format) Handler {
 	return must(SyslogNetHandler(net, addr, tag, fmtr))
 }
+
+func (m muster) SyslogHandlerPriority(p syslog.Priority, tag string, fmtr Format) Handler {
+	return must(SyslogHandlerPriority(p, tag, fmtr))
+}
+
+func (m muster) SyslogNetHandlerPriority(net, addr string, p syslog.Priority, tag string, fmtr Format) Handler {
+	return must(SyslogNetHandlerPriority(net, addr, p, tag, fmtr))
+}

--- a/syslog.go
+++ b/syslog.go
@@ -30,7 +30,7 @@ func SyslogNetHandler(net, addr string, tag string, fmtr Format) (Handler, error
 
 // SyslogHandler opens a connection to a log daemon over the network and writes
 // all log records to it. Supports the priority concept.
-func SyslogNetHandlerPriority(net, addr string, tag string, p syslog.Priority, fmtr Format) (Handler, error) {
+func SyslogNetHandlerPriority(net, addr string, p syslog.Priority, tag string, fmtr Format) (Handler, error) {
 	wr, err := syslog.Dial(net, addr, p, tag)
 	return sharedSyslog(fmtr, wr, err)
 }


### PR DESCRIPTION
I've just created two more methods to be compatible with the existent. Keeping the same logic / code as you.

This is for this issue :
https://github.com/inconshreveable/log15/issues/37