### PR TITLE
Add options to LogfmtFormat

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,11 +1,12 @@
 Contributors to log15:
 
-- Aaron L 
-- Alan Shreve 
-- Chris Hines 
-- Ciaran Downey 
-- Dmitry Chestnykh 
-- Evan Shaw 
-- Péter Szilágyi 
-- Trevor Gattis 
-- Vincent Vanackere 
+- Aaron L
+- Alan Shreve
+- Chris Hines
+- Ciaran Downey
+- Dmitry Chestnykh
+- Evan Shaw
+- Graham King
+- Péter Szilágyi
+- Trevor Gattis
+- Vincent Vanackere


### PR DESCRIPTION
Can now configure the following in `LogfmtFormat` using functional options style:
 - time format
 - float format
 - float precision

Discussion in #35.