### PR TITLE
Expose logger's current handler

### DIFF
--- a/handler_other.go
+++ b/handler_other.go
@@ -14,7 +14,11 @@ type swapHandler struct {
 }
 
 func (h *swapHandler) Log(r *Record) error {
-	return (*(*Handler)(atomic.LoadPointer(&h.handler))).Log(r)
+	return h.Get().Log(r)
+}
+
+func (h *swapHandler) Get() Handler {
+	return *(*Handler)(atomic.LoadPointer(&h.handler))
 }
 
 func (h *swapHandler) Swap(newHandler Handler) {

--- a/logger.go
+++ b/logger.go
@@ -79,6 +79,9 @@ type Logger interface {
 	// New returns a new Logger that has this logger's context plus the given context
 	New(ctx ...interface{}) Logger
 
+	// GetHandler gets the handler associated with the logger.
+	GetHandler() Handler
+
 	// SetHandler updates the logger to write records to the specified handler.
 	SetHandler(h Handler)
 
@@ -143,6 +146,10 @@ func (l *logger) Error(msg string, ctx ...interface{}) {
 
 func (l *logger) Crit(msg string, ctx ...interface{}) {
 	l.write(msg, LvlCrit, ctx)
+}
+
+func (l *logger) GetHandler() Handler {
+	return l.h.Get()
 }
 
 func (l *logger) SetHandler(h Handler) {


### PR DESCRIPTION
I needed the feature discussed in #63 and it seemed relatively straightforward. Feel free to take this or implement it in a more appropriate manner.