### PR TITLE
use consecutive WriteString calls instead of Fprintf

### DIFF
--- a/format.go
+++ b/format.go
@@ -108,7 +108,9 @@ func logfmt(buf *bytes.Buffer, ctx []interface{}, color int) {
 		if color > 0 {
 			fmt.Fprintf(buf, "\x1b[%dm%s\x1b[0m=%s", color, k, v)
 		} else {
-			fmt.Fprintf(buf, "%s=%s", k, v)
+			buf.WriteString(k)
+			buf.WriteByte('=')
+			buf.WriteString(v)
 		}
 	}
 

--- a/log15_test.go
+++ b/log15_test.go
@@ -254,14 +254,13 @@ func TestNetHandler(t *testing.T) {
 	go func() {
 		c, err := l.Accept()
 		if err != nil {
-			t.Errorf("Failed to accept conneciton: %v", err)
-			return
+			t.Fatalf("Failed to accept connection: %v", err)
 		}
 
 		rd := bufio.NewReader(c)
 		s, err := rd.ReadString('\n')
 		if err != nil {
-			t.Errorf("Failed to read string: %v", err)
+			t.Fatalf("Failed to read string: %v", err)
 		}
 
 		got := s[27:]


### PR DESCRIPTION
It seems like it's faster to use those calls than invoke Fprintf:

```
benchmark                        old ns/op     new ns/op     delta
BenchmarkStreamNoCtx-4           4755          3937          -17.20%
BenchmarkDiscard-4               816           787           -3.55%
BenchmarkCallerFileHandler-4     1879          1811          -3.62%
BenchmarkCallerFuncHandler-4     1656          1663          +0.42%
BenchmarkLogfmtNoCtx-4           3556          2784          -21.71%
BenchmarkJsonNoCtx-4             1599          1614          +0.94%
BenchmarkMultiLevelFilter-4      862           833           -3.36%
BenchmarkDescendant1-4           839           813           -3.10%
BenchmarkDescendant2-4           846           820           -3.07%
BenchmarkDescendant4-4           918           897           -2.29%
BenchmarkDescendant8-4           971           964           -0.72%
```

Fixes some places in the tests that panic if the tests don't exit immediately.