### PR TITLE
Don't call escapeString() on time values

### DIFF
--- a/format.go
+++ b/format.go
@@ -207,6 +207,12 @@ func formatLogfmtValue(value interface{}) string {
 		return "nil"
 	}
 
+	if t, ok := value.(time.Time); ok {
+		// Performance optimization: No need for escaping since the provided
+		// timeFormat doesn't have any escape characters, and escaping is
+		// expensive.
+		return t.Format(timeFormat)
+	}
 	value = formatShared(value)
 	switch v := value.(type) {
 	case bool:


### PR DESCRIPTION
escapeString() is very expensive, and we never need to escape time.Time's that
have been formatted with timeFormat, so let's return time.Time's early instead
of escaping them.

This saves a lot of allocations:

```
benchmark                        old ns/op     new ns/op     delta
BenchmarkStreamNoCtx-4           4761          4043          -15.08%
BenchmarkDiscard-4               818           788           -3.67%
BenchmarkCallerFileHandler-4     1892          1861          -1.64%
BenchmarkCallerFuncHandler-4     1690          1647          -2.54%
BenchmarkLogfmtNoCtx-4           3579          2886          -19.36%
BenchmarkJsonNoCtx-4             1650          1649          -0.06%
BenchmarkMultiLevelFilter-4      850           833           -2.00%
BenchmarkDescendant1-4           835           805           -3.59%
BenchmarkDescendant2-4           858           838           -2.33%
BenchmarkDescendant4-4           930           894           -3.87%
BenchmarkDescendant8-4           974           957           -1.75%
```

It's highly possible there's a better way to do this, maybe have formatShared()
return a `returnEarly` bool or something.