### PR TITLE
Don't allocate a byte buffer if we don't need to escape

### DIFF
--- a/format.go
+++ b/format.go
@@ -223,14 +223,22 @@ func formatLogfmtValue(value interface{}) string {
 }
 
 func escapeString(s string) string {
-	needQuotes := false
+	needsQuotes := false
+	needsEscape := false
+	for _, r := range s {
+		if r <= ' ' || r == '=' || r == '"' {
+			needsQuotes = true
+		}
+		if r == '\\' || r == '"' || r == '\n' || r == '\r' || r == '\t' {
+			needsEscape = true
+		}
+	}
+	if needsEscape == false && needsQuotes == false {
+		return s
+	}
 	e := bytes.Buffer{}
 	e.WriteByte('"')
 	for _, r := range s {
-		if r <= ' ' || r == '=' || r == '"' {
-			needQuotes = true
-		}
-
 		switch r {
 		case '\\', '"':
 			e.WriteByte('\\')
@@ -250,7 +258,7 @@ func escapeString(s string) string {
 	}
 	e.WriteByte('"')
 	start, stop := 0, e.Len()
-	if !needQuotes {
+	if !needsQuotes {
 		start, stop = 1, stop-1
 	}
 	return string(e.Bytes()[start:stop])


### PR DESCRIPTION
escapeString is expensive. Let's do one pass to check whether anything needs
to be escaped - which may be a common case - then a second pass to allocate
a buffer and do the escaping, if we need to.

```
benchmark                        old ns/op     new ns/op     delta
BenchmarkStreamNoCtx-4           4798          4352          -9.30%
BenchmarkDiscard-4               823           805           -2.19%
BenchmarkCallerFileHandler-4     1880          1864          -0.85%
BenchmarkCallerFuncHandler-4     1728          1655          -4.22%
BenchmarkLogfmtNoCtx-4           3602          3165          -12.13%
BenchmarkJsonNoCtx-4             1647          1687          +2.43%
BenchmarkMultiLevelFilter-4      864           835           -3.36%
BenchmarkDescendant1-4           836           802           -4.07%
BenchmarkDescendant2-4           862           827           -4.06%
BenchmarkDescendant4-4           949           891           -6.11%
BenchmarkDescendant8-4           974           965           -0.92%
```