### PR TITLE
Call WriteString instead of WriteByte() twice

### DIFF
--- a/format.go
+++ b/format.go
@@ -236,14 +236,11 @@ func escapeString(s string) string {
 			e.WriteByte('\\')
 			e.WriteByte(byte(r))
 		case '\n':
-			e.WriteByte('\\')
-			e.WriteByte('n')
+			e.WriteString("\\n")
 		case '\r':
-			e.WriteByte('\\')
-			e.WriteByte('r')
+			e.WriteString("\\r")
 		case '\t':
-			e.WriteByte('\\')
-			e.WriteByte('t')
+			e.WriteString("\\t")
 		default:
 			e.WriteRune(r)
 		}

--- a/log15_test.go
+++ b/log15_test.go
@@ -129,11 +129,12 @@ func TestLogfmt(t *testing.T) {
 	var nilVal *testtype
 
 	l, buf := testFormatter(LogfmtFormat())
-	l.Error("some message", "x", 1, "y", 3.2, "equals", "=", "quote", "\"", "nil", nilVal)
+	l.Error("some message", "x", 1, "y", 3.2, "equals", "=", "quote", "\"",
+		"nil", nilVal, "carriage_return", "bang"+string('\r')+"foo", "tab", "bar	baz", "newline", "foo\nbar")
 
 	// skip timestamp in comparison
 	got := buf.Bytes()[27:buf.Len()]
-	expected := []byte(`lvl=eror msg="some message" x=1 y=3.200 equals="=" quote="\"" nil=nil` + "\n")
+	expected := []byte(`lvl=eror msg="some message" x=1 y=3.200 equals="=" quote="\"" nil=nil carriage_return="bang\rfoo" tab="bar\tbaz" newline="foo\nbar"` + "\n")
 	if !bytes.Equal(got, expected) {
 		t.Fatalf("Got %s, expected %s", got, expected)
 	}


### PR DESCRIPTION
WriteByte() calls buf.grow(1) twice and appends twice, it seems better/faster
to just write the string with both bytes included.

No benchmarks, but adds some tests that this behaves correctly (they pass
against master as well).