### PR TITLE
Add the benchmarks from uber-go/zap

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -1,7 +1,11 @@
+// +build go1.3
+
 package log15
 
 import (
 	"bytes"
+	"errors"
+	"io/ioutil"
 	"testing"
 	"time"
 )
@@ -126,4 +130,78 @@ func BenchmarkDescendant8(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		lg.Info("test message")
 	}
+}
+
+// Copied from https://github.com/uber-go/zap/blob/master/benchmarks/log15_bench_test.go
+// (MIT License)
+func newLog15() Logger {
+	logger := New()
+	logger.SetHandler(StreamHandler(ioutil.Discard, JsonFormat()))
+	return logger
+}
+
+var errExample = errors.New("fail")
+
+type user struct {
+	Name      string    `json:"name"`
+	Email     string    `json:"email"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+var _jane = user{
+	Name:      "Jane Doe",
+	Email:     "jane@test.com",
+	CreatedAt: time.Date(1980, 1, 1, 12, 0, 0, 0, time.UTC),
+}
+
+func BenchmarkLog15AddingFields(b *testing.B) {
+	logger := newLog15()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			logger.Info("Go fast.",
+				"int", 1,
+				"int64", int64(1),
+				"float", 3.0,
+				"string", "four!",
+				"bool", true,
+				"time", time.Unix(0, 0),
+				"error", errExample.Error(),
+				"duration", time.Second,
+				"user-defined type", _jane,
+				"another string", "done!",
+			)
+		}
+	})
+}
+
+func BenchmarkLog15WithAccumulatedContext(b *testing.B) {
+	logger := newLog15().New(
+		"int", 1,
+		"int64", int64(1),
+		"float", 3.0,
+		"string", "four!",
+		"bool", true,
+		"time", time.Unix(0, 0),
+		"error", errExample.Error(),
+		"duration", time.Second,
+		"user-defined type", _jane,
+		"another string", "done!",
+	)
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			logger.Info("Go really fast.")
+		}
+	})
+}
+
+func BenchmarkLog15WithoutFields(b *testing.B) {
+	logger := newLog15()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			logger.Info("Go fast.")
+		}
+	})
 }


### PR DESCRIPTION
Here are the results:

```
BenchmarkLog15AddingFields-4             	   50000	     29492 ns/op
BenchmarkLog15WithAccumulatedContext-4   	   50000	     33599 ns/op
BenchmarkLog15WithoutFields-4            	  200000	      9417 ns/op
```