### PR TITLE
formatJsonValue() returns map verbatim rather than as a formatted string

### DIFF
--- a/format.go
+++ b/format.go
@@ -195,7 +195,7 @@ func formatShared(value interface{}) (result interface{}) {
 func formatJsonValue(value interface{}) interface{} {
 	value = formatShared(value)
 	switch value.(type) {
-	case int, int8, int16, int32, int64, float32, float64, uint, uint8, uint16, uint32, uint64, string:
+	case int, int8, int16, int32, int64, float32, float64, uint, uint8, uint16, uint32, uint64, string, map[string]interface{}:
 		return value
 	default:
 		return fmt.Sprintf("%+v", value)

--- a/format.go
+++ b/format.go
@@ -194,8 +194,11 @@ func formatShared(value interface{}) (result interface{}) {
 
 func formatJsonValue(value interface{}) interface{} {
 	value = formatShared(value)
+	
 	switch value.(type) {
-	case int, int8, int16, int32, int64, float32, float64, uint, uint8, uint16, uint32, uint64, string, map[string]interface{}:
+	case int, int8, int16, int32, int64, float32, float64, uint, uint8, uint16, uint32, uint64, string:
+		return value
+	case interface{}, map[string]interface{}, []interface{}:
 		return value
 	default:
 		return fmt.Sprintf("%+v", value)

--- a/log15_test.go
+++ b/log15_test.go
@@ -115,6 +115,34 @@ func TestJson(t *testing.T) {
 	validate("lvl", "eror")
 }
 
+func TestJsonMap(t *testing.T) {
+	m := map[string]interface{}{
+		"name": "gopher",
+		"age": float64(5),
+		"language": "go",
+	}
+
+	l, buf := testFormatter(JsonFormat())
+	l.Error("logging structs", "struct", m)
+	
+	var v map[string]interface{}
+	decoder := json.NewDecoder(buf)
+	if err := decoder.Decode(&v); err != nil {
+		t.Fatalf("Error decoding JSON: %v", v)
+	}
+
+	check_map := func(key string, expected interface{}) {
+		if m[key] != expected {
+			t.Fatalf("Got %v expected %v for %v", m[key], expected, key)
+		}
+	}
+
+	mv := v["struct"].(map[string]interface{})
+	check_map("name", mv["name"])
+	check_map("age", mv["age"])
+	check_map("language", mv["language"])
+}
+
 type testtype struct {
 	name string
 }


### PR DESCRIPTION
For Issue #93.

Instead of coercing maps into a string representation (which later ruins the json marshaling of maps) we return maps as is so that Go's json library can automatically convert maps into equivalent JSON recursively, as is the standard behavior.
