### PR TITLE
Ability to wrap log.Warn("message", "key", value); to writelog("warn"…

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -2,6 +2,7 @@ package log15
 
 import (
 	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/go-stack/stack"
@@ -161,6 +162,9 @@ func normalize(ctx []interface{}) []interface{} {
 	if len(ctx) == 1 {
 		if ctxMap, ok := ctx[0].(Ctx); ok {
 			ctx = ctxMap.toArray()
+		}
+		if reflect.TypeOf(ctx[0]).Kind() == reflect.Slice {
+			ctx = ctx[0].([]interface{})
 		}
 	}
 


### PR DESCRIPTION
…, "message", "key", value)

I have case like this : 
i want to wrap log.warn inside my own function that define default handler for my whole project.

My function would be like this

```go
func Writelog(tipe string, message string, ctx ...interface{}) {
// ....
// .... My own handler
// ....

	switch tipe {
	case "info":
		Log.Info(message, ctx)
	case "warn":
		Log.Warn(message, ctx)
	case "error":
		Log.Error(message, ctx)
	case "crit":
		Log.Crit(message, ctx)
	case "debug":
		Log.Debug(message, ctx)
	}
}
```

when my app call that function like

```Writelog("crit", "Danger, earth destroyed", "Help ETA: ", 15)```

log15  will receive ctx as [[Help ETA:  15]] instead of [Help ETA:  15]  and log output will appended with 
```LOG15_ERROR= LOG15_ERROR="Normalized odd number of arguments by adding nil"```

This pull request will fix this.