### PR TITLE
Update build matrix for Go 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,12 @@
 language: go
+go_import_path: github.com/inconshreveable/log15
+sudo: false
 
 go:
   - 1.3
   - 1.4
   - 1.5
   - 1.6
+  - 1.7
+  - 1.8
   - tip


### PR DESCRIPTION
Also get go_import_path working correctly for builds on forks.