### PR TITLE
Allow the user to customize the stack depth to skip.

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -7,6 +7,8 @@ import (
 	"github.com/go-stack/stack"
 )
 
+const defaultStackDepth = 2
+
 const timeKey = "t"
 const lvlKey = "lvl"
 const msgKey = "msg"
@@ -97,6 +99,8 @@ type Logger interface {
 type logger struct {
 	ctx []interface{}
 	h   *swapHandler
+
+	stackDepth int
 }
 
 func (l *logger) write(msg string, lvl Lvl, ctx []interface{}) {
@@ -105,7 +109,7 @@ func (l *logger) write(msg string, lvl Lvl, ctx []interface{}) {
 		Lvl:  lvl,
 		Msg:  msg,
 		Ctx:  newContext(l.ctx, ctx),
-		Call: stack.Caller(2),
+		Call: stack.Caller(l.stackDepth),
 		KeyNames: RecordKeyNames{
 			Time: timeKey,
 			Msg:  msgKey,
@@ -114,8 +118,17 @@ func (l *logger) write(msg string, lvl Lvl, ctx []interface{}) {
 	})
 }
 
+// SetStackDepth resets the stack depth.
+//
+// The argument, depth, is the depth from the app call to logger, which doesn't
+// contain the inner stack depth of logger. The default is 0.
+func (l *logger) SetStackDepth(depth int) Logger {
+	l.stackDepth = depth + defaultStackDepth
+	return l
+}
+
 func (l *logger) New(ctx ...interface{}) Logger {
-	child := &logger{newContext(l.ctx, ctx), new(swapHandler)}
+	child := &logger{newContext(l.ctx, ctx), new(swapHandler), defaultStackDepth}
 	child.SetHandler(l.h)
 	return child
 }

--- a/root.go
+++ b/root.go
@@ -22,7 +22,7 @@ func init() {
 		StderrHandler = StreamHandler(colorable.NewColorableStderr(), TerminalFormat())
 	}
 
-	root = &logger{[]interface{}{}, new(swapHandler)}
+	root = &logger{[]interface{}{}, new(swapHandler), defaultStackDepth}
 	root.SetHandler(StdoutHandler)
 }
 


### PR DESCRIPTION
This PR removes the hard-coded stack depth to skip. So the user can customize it by the actual demand.

For example, I want to wrap `log15.Logger` in my struct.
```go
type MyStruct struct {
	logger *log15.Logger

	// Other fields
	// ...
}

func (m *MyStruct) LogInfo(msg string) {
	m.logger.Info(msg)
}

my := MyStruct{
	logger: log15.New().SetStackDepth(1)
}

my.LogInfo("test")
```

Before this, I have to discard the stack information of `log15.Logger` and rewrite it myself.