### PR TITLE
Call t.Fatalf from main goroutine

### DIFF
--- a/log15_test.go
+++ b/log15_test.go
@@ -255,13 +255,15 @@ func TestNetHandler(t *testing.T) {
 	go func() {
 		c, err := l.Accept()
 		if err != nil {
-			t.Fatalf("Failed to accept connection: %v", err)
+			errs <- fmt.Errorf("Failed to accept connection: %v", err)
+			return
 		}
 
 		rd := bufio.NewReader(c)
 		s, err := rd.ReadString('\n')
 		if err != nil {
-			t.Fatalf("Failed to read string: %v", err)
+			errs <- fmt.Errorf("Failed to read string: %v", err)
+			return
 		}
 
 		got := s[27:]
@@ -284,8 +286,10 @@ func TestNetHandler(t *testing.T) {
 	select {
 	case <-time.After(time.Second):
 		t.Fatalf("Test timed out!")
-	case <-errs:
-		// ok
+	case err := <-errs:
+		if err != nil {
+			t.Fatal(err)
+		}
 	}
 }
 


### PR DESCRIPTION
staticcheck warns about calling t.Fatalf from a goroutine. From the
docs for `t.FailNow`:

> FailNow must be called from the goroutine running the test or
> benchmark function, not from other goroutines created during the
> test.

https://godoc.org/testing#T.FailNow