### PR TITLE
Fix build under appengine

### DIFF
--- a/term/terminal_notwindows.go
+++ b/term/terminal_notwindows.go
@@ -3,7 +3,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build linux,!appengine darwin freebsd openbsd netbsd
+// +build linux,!appengine,darwin,freebsd,openbsd,netbsd
 
 package term
 

--- a/term/terminal_notwindows.go
+++ b/term/terminal_notwindows.go
@@ -3,7 +3,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build linux,!appengine,darwin,freebsd,openbsd,netbsd
+// +build linux,!appengine,!darwin,!freebsd,!openbsd,!netbsd
 
 package term
 


### PR DESCRIPTION
Seems like appengine golang currently fails the build because this !appengine isn't being parsed properly. I believe comma-separating the fields is the correct fix there? It functions after this change locally.
