### PR TITLE
logger: fix typo in log level to string function

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -104,7 +104,7 @@ the context.
 
 This will output a line that looks like:
 
-    lvl=eror t=2014-05-02T16:07:23-0700 msg="open file" err="file not found" caller=data.go:42
+    lvl=error t=2014-05-02T16:07:23-0700 msg="open file" err="file not found" caller=data.go:42
 
 Here's an example that logs the call stack rather than just the call site.
 
@@ -115,7 +115,7 @@ Here's an example that logs the call stack rather than just the call site.
 
 This will output a line that looks like:
 
-    lvl=eror t=2014-05-02T16:07:23-0700 msg="open file" err="file not found" stack="[pkg/data.go:42 pkg/cmd/main.go]"
+    lvl=error t=2014-05-02T16:07:23-0700 msg="open file" err="file not found" stack="[pkg/data.go:42 pkg/cmd/main.go]"
 
 The "%+v" format instructs the handler to include the path of the source file
 relative to the compile time GOPATH. The github.com/go-stack/stack package

--- a/log15_test.go
+++ b/log15_test.go
@@ -112,7 +112,7 @@ func TestJson(t *testing.T) {
 	validate("msg", "some message")
 	validate("x", float64(1)) // all numbers are floats in JSON land
 	validate("y", 3.2)
-	validate("lvl", "eror")
+	validate("lvl", "error")
 }
 
 type testtype struct {
@@ -134,7 +134,7 @@ func TestLogfmt(t *testing.T) {
 
 	// skip timestamp in comparison
 	got := buf.Bytes()[27:buf.Len()]
-	expected := []byte(`lvl=eror msg="some message" x=1 y=3.200 equals="=" quote="\"" nil=nil carriage_return="bang\rfoo" tab="bar\tbaz" newline="foo\nbar"` + "\n")
+	expected := []byte(`lvl=error msg="some message" x=1 y=3.200 equals="=" quote="\"" nil=nil carriage_return="bang\rfoo" tab="bar\tbaz" newline="foo\nbar"` + "\n")
 	if !bytes.Equal(got, expected) {
 		t.Fatalf("Got %s, expected %s", got, expected)
 	}

--- a/logger.go
+++ b/logger.go
@@ -34,7 +34,7 @@ func (l Lvl) String() string {
 	case LvlWarn:
 		return "warn"
 	case LvlError:
-		return "eror"
+		return "error"
 	case LvlCrit:
 		return "crit"
 	default:


### PR DESCRIPTION
It should be "error" not "eror".

I'm not sure if it's really a typo or intended to keep the levels 4-letters long.
If that's the case I would prefer to use a 3-letter "err" instead of using a wrong spelling.