### PR TITLE
Add SetRecordKeyNames to Logger interface

### DIFF
--- a/log15_test.go
+++ b/log15_test.go
@@ -568,3 +568,20 @@ func TestConcurrent(t *testing.T) {
 		}
 	}
 }
+
+func TestSetRecordKeyNames(t *testing.T) {
+	defaultKeyNames := RecordKeyNames{Time: "t", Lvl: "lvl", Msg: "msg"}
+	keyNames := RecordKeyNames{Time: "timestamp", Lvl: "level", Msg: "message"}
+
+	l, _, r := testLogger()
+	l.Info("hi")
+	if r.KeyNames != defaultKeyNames {
+		t.Errorf("initial key names are incorrect:%#v", r.KeyNames)
+	}
+
+	l.SetRecordKeyNames(keyNames)
+	l.New("x", "y").Info("hi")
+	if r.KeyNames != keyNames {
+		t.Errorf("key names not preserved: %#v", r.KeyNames)
+	}
+}

--- a/log15_test.go
+++ b/log15_test.go
@@ -576,7 +576,7 @@ func TestSetRecordKeyNames(t *testing.T) {
 	l, _, r := testLogger()
 	l.Info("hi")
 	if r.KeyNames != defaultKeyNames {
-		t.Errorf("initial key names are incorrect:%#v", r.KeyNames)
+		t.Errorf("initial key names are incorrect: %#v", r.KeyNames)
 	}
 
 	l.SetRecordKeyNames(keyNames)

--- a/root.go
+++ b/root.go
@@ -23,7 +23,13 @@ func init() {
 		StderrHandler = StreamHandler(colorable.NewColorableStderr(), TerminalFormat())
 	}
 
-	root = &logger{[]interface{}{}, new(swapHandler)}
+	defaultKeyNames := RecordKeyNames{
+		Time: "t",
+		Msg:  "msg",
+		Lvl:  "lvl",
+	}
+
+	root = &logger{[]interface{}{}, new(swapHandler), defaultKeyNames}
 	root.SetHandler(StdoutHandler)
 }
 


### PR DESCRIPTION
Allow applications to override the common key names (msg/lvl/t).

This is useful for some log aggregation services which only parse specific field names.  LogDNA for example only parses "level" and "message" keys.

Usage example:
```go
logger := log15.New()
logger.SetRecordKeyNames(log15.RecordKeyNames{
    Time: "timestamp", Msg: "message", Lvl: "level"})
```

Fixes https://github.com/inconshreveable/log15/issues/147