### PR TITLE
add configurable feature with yaml file

### DIFF
--- a/conf.go
+++ b/conf.go
@@ -1,0 +1,74 @@
+package log15
+
+import(
+    "io/ioutil"
+    "gopkg.in/yaml.v2"
+)
+
+// config file will be parsed to be Configuration struct
+type Configuration struct{
+    handlers map[string]*CfgHandler
+    loggers map[string]*CfgLogger
+}
+
+type CfgHandler struct{
+    handler_type string
+    path string
+}
+
+type CfgLogger struct{
+    level string
+    handler_name string
+}
+
+
+// read from config file to make Configuration struct.
+func readConfig() (*Configuration, error){
+    conf := make(map[interface{}]interface{})
+    buf, err := ioutil.ReadFile("./log15.yml")
+    if nil == err {
+        err = yaml.Unmarshal(buf, &conf)
+        if nil == err{
+            return makeConfiguration(conf)
+        }
+        return nil, err
+    }
+    return nil, err
+}
+
+func newConfiguration() *Configuration {
+    out := new(Configuration)
+    out.handlers = make(map[string]*CfgHandler)
+    out.loggers = make(map[string]*CfgLogger)
+    return out
+}
+
+func makeConfiguration(confMap map[interface{}]interface{}) (*Configuration, error) {
+    cmloggers := confMap["loggers"].(map[interface{}]interface{})
+    cmhandlers := confMap["handlers"].(map[interface{}]interface{})
+
+    out := newConfiguration()
+    for lgName, cmlogger := range cmloggers {
+        logger := new(CfgLogger) 
+        for k, v := range cmlogger.(map[interface{}]interface{}) {
+            if k.(string) == "level"{
+                logger.level = v.(string)
+            }else if k.(string) == "handler_name"{
+                logger.handler_name = v.(string)
+            }
+        }
+        out.loggers[lgName.(string)] = logger
+    }
+    for hdName, cmhandler := range cmhandlers {
+        handler := new(CfgHandler) 
+        for k, v := range cmhandler.(map[interface{}]interface{}) {
+            if k.(string) == "handler_type" {
+                handler.handler_type = v.(string)
+            }else if k.(string) == "path"{
+                handler.path = v.(string)
+            }
+        }
+        out.handlers[hdName.(string)] = handler
+    }
+    return out, nil
+}

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,41 @@
+package log15
+
+import(
+    "testing"
+    "os"
+    "io/ioutil"
+    "strings"
+)
+
+func TestDefaultLogger(t *testing.T){
+    lg, err := GetLogger("getdefault")
+    if err != nil || nil == lg || lg != root{
+        t.Fatalf("Failed to get root logger.")
+    }
+}
+
+func TestGetFileLogger(t *testing.T){
+    err := os.Remove("./test.log")
+    if err != nil {
+        if !os.IsNotExist(err) {
+            t.Fatalf(err.Error())
+        }
+    }
+
+    // The log file is creaded when the handler is made,
+    // so we initialize from config file manually.
+    initByConf() 
+
+    lg, err := GetLogger("log_test_log_file")
+    if err != nil || nil == lg  || lg == root{
+        t.Fatalf("Failed to get file logger.")
+    }
+
+    logStr := "write log in file!"
+    lg.Info(logStr)
+    content,err := ioutil.ReadFile("./test.log")
+
+    if strings.Index(string(content), logStr) < 0 {
+        t.Fatalf("Failed to write log in test.log, content:%s", string(content))
+    }
+}

--- a/log15.yml
+++ b/log15.yml
@@ -1,0 +1,18 @@
+# sample for configuration of log by log15
+handlers:
+  # name of handler which can be defined at will
+  console:
+    handler_type: stdout
+  file:
+    handler_type: file
+    path: ./test.log
+
+loggers:
+  # name of logger which can be defined at will
+  root2:
+    level: error
+    # name of handler which should be defined in element handlers
+    handler_name: console
+  log_test_log_file:
+    level: debug
+    handler_name: file

--- a/loggers_by_config.go
+++ b/loggers_by_config.go
@@ -1,0 +1,76 @@
+package log15
+
+import (
+    "fmt"
+)
+
+type Loggers map[string]*logger
+
+var (
+    // store logger which is initialized from configuration file.
+    loggers Loggers 
+)
+
+func initByConf() {
+    loggers = Loggers{"root":root}
+    makeLoggersFromConf()
+}
+
+// get specific logger by name.
+// when you get logger by this method,you can use logger with the former way.
+// return root if the name is not defined in the configuration file.
+func GetLogger(name string) (*logger, error){
+    if nil == loggers {
+        initByConf()
+    }
+    if v, ok := loggers[name]; ok{
+        return v, nil
+    }else{
+        return loggers["root"], nil
+    }
+}
+
+func makeHandler(conf *Configuration, name string) (Handler, error){
+    cfHandler, ok := conf.handlers[name]
+    if !ok {
+        return nil, fmt.Errorf("no handler named %s defined in configuraiton file", name)
+    }
+    var (
+        err error
+        handler Handler
+    )
+    switch cfHandler.handler_type{
+    case "file":
+        handler, err = FileHandler(cfHandler.path, LogfmtFormat())
+        if err != nil {
+            return nil, err
+        }
+    case "stdout":
+        handler = StdoutHandler
+    }
+    return handler, err
+}
+
+func makeLogger(conf *Configuration, name string) (*logger, error){
+    handler, err := makeHandler(conf, conf.loggers[name].handler_name)
+    if err != nil {
+        return nil, err
+    }
+    lg := &logger{[]interface{}{}, new(swapHandler)} 
+    lg.SetHandler(handler)
+    return lg, nil
+}
+
+func makeLoggersFromConf() {
+    conf, err := readConfig()
+    if err != nil {
+        fmt.Println(err)
+        return 
+    }
+    for lgname, _ := range conf.loggers {
+        loggers[lgname], err = makeLogger(conf, lgname)
+        if err != nil {
+            continue
+        }
+    }
+}


### PR DESCRIPTION
I try to add a simple function to make logger by configuration of yaml file,Hoping log15 can be used by configuration as log4j.

The config file "log15.yml" shows how to config logger by now. And The test code in "config_test.go" shows how to get logger configurated in "log15.yml". After getting logger, then it can by used as former.

If it`s welcomed, I will continue to improve the configurable feature.