### PR TITLE
logger: make LvlFromString slightly more flexible

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -2,6 +2,7 @@ package log15
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/go-stack/stack"
@@ -57,7 +58,12 @@ func LvlFromString(lvlString string) (Lvl, error) {
 	case "crit":
 		return LvlCrit, nil
 	default:
-		return LvlDebug, fmt.Errorf("Unknown level: %v", lvlString)
+		// try to catch e.g. "INFO", "WARN" without slowing down the fast path
+		lower := strings.ToLower(lvlString)
+		if lower != lvlString {
+			return LvlFromString(lower)
+		}
+		return LvlDebug, fmt.Errorf("log15: unknown level: %v", lvlString)
 	}
 }
 

--- a/logger_test.go
+++ b/logger_test.go
@@ -1,0 +1,30 @@
+package log15
+
+import "testing"
+
+var lvlCases = []struct {
+	in  string
+	out Lvl
+}{
+	{"warn", LvlWarn},
+	{"eror", LvlError},
+	{"error", LvlError},
+	{"EROR", LvlError},
+	{"ERROR", LvlError},
+	{"UNK", -1},
+}
+
+func TestLvlFromString(t *testing.T) {
+	for _, tt := range lvlCases {
+		lvl, err := LvlFromString(tt.in)
+		if err != nil {
+			if tt.out != -1 {
+				t.Errorf("expected level %q but got err %v", tt.out, err)
+			}
+		} else {
+			if lvl != tt.out {
+				t.Errorf("LvlFromString(%q): want %q got %q", tt.in, tt.out, lvl)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Also return the correct level for "WARN", "Warn" etc. While we are at
it, lowercase the returned error string - staticcheck among others
warns about uppercased error messages.