### PR TITLE
Add Go module support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,16 @@ you must vendor the library.
 
 ## Importing
 
+Master branch:
+
 ```go
 import log "github.com/inconshreveable/log15"
+```
+
+Stable release with Go module support:
+
+```go
+import log "github.com/inconshreveable/log15/v3"
 ```
 
 ## Examples

--- a/ext/ext_test.go
+++ b/ext/ext_test.go
@@ -2,9 +2,10 @@ package ext
 
 import (
 	"errors"
-	log "github.com/inconshreveable/log15"
 	"math"
 	"testing"
+
+	log "github.com/inconshreveable/log15/v3"
 )
 
 func testHandler() (log.Handler, *log.Record) {

--- a/ext/handler.go
+++ b/ext/handler.go
@@ -6,7 +6,7 @@ import (
 	"sync/atomic"
 	"unsafe"
 
-	log "github.com/inconshreveable/log15"
+	log "github.com/inconshreveable/log15/v3"
 )
 
 // EscalateErrHandler wraps another handler and passes all records through

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,10 @@
+module github.com/inconshreveable/log15/v3
+
+go 1.9
+
+require (
+	github.com/go-stack/stack v1.8.0
+	github.com/mattn/go-colorable v0.1.6
+	github.com/mattn/go-isatty v0.0.12
+	golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/go-stack/stack v1.8.0 h1:5SgMzNM5HxrEjV0ww2lTmX6E2Izsfxas4+YHWRs3Lsk=
+github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/mattn/go-colorable v0.1.6 h1:6Su7aK7lXmJ/U79bYtBjLNaha4Fs1Rg9plHpcH+vvnE=
+github.com/mattn/go-colorable v0.1.6/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
+github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
+github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
+golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd h1:xhmwyvizuTgC2qz7ZlMluP20uW+C3Rm0FD/WLDX8884=
+golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=


### PR DESCRIPTION
This PR adds a go.mod file and closes #152 

As per [recommendations](https://github.com/golang/go/wiki/Modules#releasing-modules-v2-or-higher) from the Go Modules wiki page:

1. To fully implement this module support a new major release needs to be done (v3)
2. Therefore, I've changed import paths in this package to reflect this: `log "github.com/inconshreveable/log15/v3"`
3. Readme is updated accordingly.
4. Personal experience: Go expects a 3-numbered version, or modules will not work. So next release should be tagged like `v3.0.0`
5. It is recommended (but not required) to keep a separate `v3` branch from which `v3` releases are done. This has to do with long term support of individual module versions.

## Go version support

Modules is supported by Go versions `1.9.7+`, `1.10.3+`, or `1.11+`. `1.9` is the lowest version in `.travis.yml`. Hence, `go.mod` has `go 1.9` as minimal supported version for this package.

## Tested

I've done a [test release ](https://github.com/usrpro/log15/releases/tag/v3.1.0)on my own fork of this repository to verify things are done right. I've tested `go get` and module versioning in a dependent package.

**Note:** package name in my test release reflects my own repository path, while this PR reflects `github.com/inconshreveable/log15`

In `go.mod`:

````
require github.com/usrpro/log15/v3 v3.1.0
````

Import:

````
import log "github.com/usrpro/log15/v3"
````

Ran:
````
$ go get -u -v ./...
go: downloading github.com/usrpro/log15/v3 v3.1.0
github.com/usrpro/log15/v3
````

All worked OK :ballot_box_with_check: 