### PR TITLE
Travis-ci: added support for ppc64le & go 1.14 & 1.15

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,15 @@
 language: go
 go_import_path: github.com/inconshreveable/log15
 sudo: false
-
+arch:
+  - AMD64
+  - ppc64le
 go:
   - 1.9.x
   - 1.10.x
   - 1.11.x
   - 1.12.x
   - 1.13.x
+  - 1.14.x
+  - 1.15.x
   - master


### PR DESCRIPTION
Signed-off-by: Devendranath Thadi <devendranath.thadi3@gmail.com>

Added power support for the travis.yml file with ppc64le and updated latest go versions 1.14 & 1.15. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing.