### PR TITLE
Improve logger documentation

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -95,11 +95,49 @@ type Logger interface {
 	// SetHandler updates the logger to write records to the specified handler.
 	SetHandler(h Handler)
 
-	// Log a message at the given level with context key/value pairs
+	// Log a message at the debug level with context key/value pairs
+	//
+	// # Usage Examples
+	//
+	//	log.Debug("msg")
+	//	log.Debug("msg", "key1", val1)
+	//	log.Debug("msg", "key1", val1, "key2", val2)
 	Debug(msg string, ctx ...interface{})
+
+	// Log a message at the info level with context key/value pairs
+	//
+	// # Usage Examples
+	//
+	//	log.Info("msg")
+	//	log.Info("msg", "key1", val1)
+	//	log.Info("msg", "key1", val1, "key2", val2)
 	Info(msg string, ctx ...interface{})
+
+	// Log a message at the warn level with context key/value pairs
+	//
+	// # Usage Examples
+	//
+	//	log.Warn("msg")
+	//	log.Warn("msg", "key1", val1)
+	//	log.Warn("msg", "key1", val1, "key2", val2)
 	Warn(msg string, ctx ...interface{})
+
+	// Log a message at the error level with context key/value pairs
+	//
+	// # Usage Examples
+	//
+	//	log.Error("msg")
+	//	log.Error("msg", "key1", val1)
+	//	log.Error("msg", "key1", val1, "key2", val2)
 	Error(msg string, ctx ...interface{})
+
+	// Log a message at the crit level with context key/value pairs
+	//
+	// # Usage Examples
+	//
+	//	log.Crit("msg")
+	//	log.Crit("msg", "key1", val1)
+	//	log.Crit("msg", "key1", val1, "key2", val2)
 	Crit(msg string, ctx ...interface{})
 }
 

--- a/root.go
+++ b/root.go
@@ -43,26 +43,66 @@ func Root() Logger {
 // runtime.Caller(2) always refers to the call site in client code.
 
 // Debug is a convenient alias for Root().Debug
+//
+// Log a message at the debug level with context key/value pairs
+//
+// # Usage Examples
+//
+//	log.Debug("msg")
+//	log.Debug("msg", "key1", val1)
+//	log.Debug("msg", "key1", val1, "key2", val2)
 func Debug(msg string, ctx ...interface{}) {
 	root.write(msg, LvlDebug, ctx)
 }
 
 // Info is a convenient alias for Root().Info
+//
+// Log a message at the info level with context key/value pairs
+//
+// # Usage Examples
+//
+//	log.Info("msg")
+//	log.Info("msg", "key1", val1)
+//	log.Info("msg", "key1", val1, "key2", val2)
 func Info(msg string, ctx ...interface{}) {
 	root.write(msg, LvlInfo, ctx)
 }
 
 // Warn is a convenient alias for Root().Warn
+//
+// Log a message at the warn level with context key/value pairs
+//
+// # Usage Examples
+//
+//	log.Warn("msg")
+//	log.Warn("msg", "key1", val1)
+//	log.Warn("msg", "key1", val1, "key2", val2)
 func Warn(msg string, ctx ...interface{}) {
 	root.write(msg, LvlWarn, ctx)
 }
 
 // Error is a convenient alias for Root().Error
+//
+// Log a message at the error level with context key/value pairs
+//
+// # Usage Examples
+//
+//	log.Error("msg")
+//	log.Error("msg", "key1", val1)
+//	log.Error("msg", "key1", val1, "key2", val2)
 func Error(msg string, ctx ...interface{}) {
 	root.write(msg, LvlError, ctx)
 }
 
 // Crit is a convenient alias for Root().Crit
+//
+// Log a message at the crit level with context key/value pairs
+//
+// # Usage Examples
+//
+//	log.Crit("msg")
+//	log.Crit("msg", "key1", val1)
+//	log.Crit("msg", "key1", val1, "key2", val2)
 func Crit(msg string, ctx ...interface{}) {
 	root.write(msg, LvlCrit, ctx)
 }


### PR DESCRIPTION
A super small change to improve development ergonomics. Whenever I use the logger, I end up needing to reference the godoc to remember the exact syntax, as it is not evident from the function signature. By making these changes, the IDE tooltip now looks like the below. The comments are added onto each individual method so that all of them now have the helpful IDE tooltips.

![image](https://user-images.githubusercontent.com/26288229/220430902-6025cc57-66bf-49c5-948b-2e39d4bdbd96.png)