### PR TITLE
fix: Add back v3/ext/id.go

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## v3.2.0 - 2026-05-13
 
+- Restored `v3/ext.RandId`, which was accidentally omitted from v3.1.0 and
+  could break upgrades from `v3.0.0-testing.5`. Thanks to Jonathan Stacks for
+  the fix.
 - Removed the `github.com/mattn/go-colorable` dependency from the root and
   `v3` modules. This also removes the transitive
   `github.com/mattn/go-isatty` dependency.

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -12,6 +12,7 @@ Evan Shaw <edsrzf@gmail.com>
 Gonzalo Serrano <boikot@gmail.com>
 Jeremy <jrbudnack@starkandwayne.com>
 Jonathan Rudenberg <jonathan@titanous.com>
+Jonathan Stacks <jonstacks@users.noreply.github.com>
 Josh Robson Chase <josh@robsonchase.com>
 Kang Seong-Min <kang.seongmin@gmail.com>
 Kevin Burke <kevin@burke.dev>

--- a/v3/ext/ext_test.go
+++ b/v3/ext/ext_test.go
@@ -108,3 +108,14 @@ func TestErrorHandler(t *testing.T) {
 		t.Fatalf("Expected debug level message to be escalated to LvlError")
 	}
 }
+
+func TestRandId(t *testing.T) {
+	t.Parallel()
+
+	if id := RandId(8); len(id) != 16 {
+		t.Fatalf("RandId(8) length = %d, want 16", len(id))
+	}
+	if id := RandId(0); id != "" {
+		t.Fatalf("RandId(0) = %q, want empty string", id)
+	}
+}

--- a/v3/ext/id.go
+++ b/v3/ext/id.go
@@ -1,0 +1,47 @@
+package ext
+
+import (
+	"fmt"
+	"math/rand"
+	"sync"
+	"time"
+)
+
+var r = rand.New(&lockedSource{src: rand.NewSource(time.Now().Unix())})
+
+// RandId creates a random identifier of the requested length.
+// Useful for assigning mostly-unique identifiers for logging
+// and identification that are unlikely to collide because of
+// short lifespan or low set cardinality
+func RandId(idlen int) string {
+	b := make([]byte, idlen)
+	var randVal uint32
+	for i := 0; i < idlen; i++ {
+		byteIdx := i % 4
+		if byteIdx == 0 {
+			randVal = r.Uint32()
+		}
+		b[i] = byte((randVal >> (8 * uint(byteIdx))) & 0xFF)
+	}
+	return fmt.Sprintf("%x", b)
+}
+
+// lockedSource is a wrapper to allow a rand.Source to be used
+// concurrently (same type as the one used internally in math/rand).
+type lockedSource struct {
+	lk  sync.Mutex
+	src rand.Source
+}
+
+func (r *lockedSource) Int63() (n int64) {
+	r.lk.Lock()
+	n = r.src.Int63()
+	r.lk.Unlock()
+	return
+}
+
+func (r *lockedSource) Seed(seed int64) {
+	r.lk.Lock()
+	r.src.Seed(seed)
+	r.lk.Unlock()
+}


### PR DESCRIPTION
We found this issue in https://github.com/ngrok/ngrok-go/issues/213#issuecomment-3198232878

This file was removed between v3.0.0-testing.5 and v3.1.0. This can cause issues when modules depend on v3.0.0-testing.5. Running `go get -u github.com/me/my-module` will update the dependency on log15 to the latest "minor" version which is v3.1.0. This version is missing the `v3/ext/id.go` file and causes programs not to be able to build when upgrading.

I believe releasing a v3.1.1 with this file being reinstated will help prevent this issue.

Reading https://go.dev/ref/mod#versions,

> The pre-release suffix indicates a version is a [pre-release](https://go.dev/ref/mod#glos-pre-release-version). Pre-release versions sort before the corresponding release versions. For example, v1.2.3-pre comes before v1.2.3.

> A version is considered unstable if its major version is 0 or it has a pre-release suffix. Unstable versions are not subject to compatibility requirements. For example, v0.2.0 may not be compatible with v0.1.0, and v1.5.0-beta may not be compatible with v1.5.0.

It seems like log15 removing this function is valid so this could just be an issue with the go tooling. I still think releasing a patch version that adds this back would help prevent paper cuts like this.