### PR TITLE
compat: update legacy log15 dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,50 @@
+# Changelog
+
+## v3.2.0 - 2026-05-13
+
+- Removed the `github.com/mattn/go-colorable` dependency from the root and
+  `v3` modules. This also removes the transitive
+  `github.com/mattn/go-isatty` dependency.
+- Switched terminal detection to `golang.org/x/term.IsTerminal`.
+- Kept the deprecated root `term` package available for source compatibility.
+  `term.IsTty` now delegates to `x/term`, and the exported `Termios` types are
+  still present but marked deprecated.
+- Updated `compat` to require the root module version that no longer depends on
+  `go-colorable`, allowing `go mod tidy` to remove `go-colorable`,
+  `go-isatty`, and stale `x/sys` checksum entries from `compat`.
+- Updated module metadata and CI configuration to current Go and `x/sys`
+  versions.
+
+## v3.1.0 - 2025-07-17
+
+- Prepared the `github.com/inconshreveable/log15/v3` module for release.
+- Added the `compat` module for adapting between legacy log15 interfaces and
+  the v3 APIs.
+- Improved compatibility coverage for handlers, loggers, record conversion, and
+  key name handling.
+- Preserved the stack-backed caller record work from Nikolay Petrov, including
+  allocation and benchmark follow-ups.
+
+## v3.0.0-testing.5 - 2022-11-29
+
+- Added the initial `github.com/inconshreveable/log15/v3` module layout.
+- Added compatibility wrappers for legacy handlers and loggers.
+- Updated import paths and formatting for the v3 module.
+- Thanks to Josh Robson Chase for the v3 compatibility work.
+
+## v2.16.0 - 2022-11-21
+
+- Switched root terminal detection to `golang.org/x/term`.
+- Added GitHub Actions CI.
+- Added CI coverage for `ppc64le`, from Devendranath Thadi.
+
+## v2.15-no-caller - 2020-08-03
+
+- Added a variant that removes caller reporting.
+- Thanks to Nikolay Petrov for the caller and stack record work that led to this
+  release path.
+
+## v2.15 - 2020-01-09
+
+- Made `LvlFromString` more flexible.
+- Updated CI coverage for newer Go versions.

--- a/compat/go.mod
+++ b/compat/go.mod
@@ -4,14 +4,12 @@ go 1.24.0
 
 require (
 	// can't use "replace" directive for this import which is just the parent module
-	github.com/inconshreveable/log15 v0.0.0-20260226202544-23f08a1ae593
+	github.com/inconshreveable/log15 v0.0.0-20260513164642-de25451ef092
 	github.com/inconshreveable/log15/v3 v3.1.0
 )
 
 require (
 	github.com/go-stack/stack v1.8.1 // indirect
-	github.com/mattn/go-colorable v0.1.14 // indirect
-	github.com/mattn/go-isatty v0.0.20 // indirect
 	golang.org/x/sys v0.41.0 // indirect
 	golang.org/x/term v0.40.0 // indirect
 )

--- a/compat/go.sum
+++ b/compat/go.sum
@@ -1,12 +1,7 @@
 github.com/go-stack/stack v1.8.1 h1:ntEHSVwIt7PNXNpgPmVfMrNhLtgjlmnZha2kOpuRiDw=
 github.com/go-stack/stack v1.8.1/go.mod h1:dcoOX6HbPZSZptuspn9bctJ+N/CnF5gGygcUP3XYfe4=
-github.com/inconshreveable/log15 v0.0.0-20260226202544-23f08a1ae593 h1:r54VtS1syAHL3eErcsHn8T2nOUUb00EKbwRf1AMfXOA=
-github.com/inconshreveable/log15 v0.0.0-20260226202544-23f08a1ae593/go.mod h1:42bYR/F2ujq7G+m8fbhOMy0MXg16W1DkBVPL8p3W6eY=
-github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHPsaIE=
-github.com/mattn/go-colorable v0.1.14/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stgPZH1UqBm1s8=
-github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
-github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
-golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+github.com/inconshreveable/log15 v0.0.0-20260513164642-de25451ef092 h1:BV+p2pKJZJhQYqsBpV4rYslYpp4GK8lGgknWvSs++iM=
+github.com/inconshreveable/log15 v0.0.0-20260513164642-de25451ef092/go.mod h1:AFovE2Hxbq9EPtxzigArlx30Pm0kC/bp19wSDnG9W54=
 golang.org/x/sys v0.41.0 h1:Ivj+2Cp/ylzLiEU89QhWblYnOE9zerudt9Ftecq2C6k=
 golang.org/x/sys v0.41.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 golang.org/x/term v0.40.0 h1:36e4zGLqU4yhjlmxEaagx2KuYbJq3EwY8K943ZsHcvg=


### PR DESCRIPTION
Point the compatibility module at the merged log15 commit that removed go-colorable from the root module. Tidying now drops go-colorable, go-isatty, and the stale x/sys checksum entries from compat.