### PR TITLE
Perf improvements

### DIFF
--- a/v3/bench_test.go
+++ b/v3/bench_test.go
@@ -219,3 +219,75 @@ func newHandler() Handler {
 	handler := StreamHandler(ioutil.Discard, logformat)
 	return LvlFilterHandler(lvl, handler)
 }
+
+// Benchmarks targeting fmt.Sprintf allocation hotspots in format.go
+
+func BenchmarkLogfmtWithIntCtx(b *testing.B) {
+	r := Record{
+		Time:     time.Now(),
+		Lvl:      LvlInfo,
+		Msg:      "test message",
+		Ctx:      []interface{}{"count", 42, "size", int64(1024), "code", uint32(200), "offset", uint64(9999)},
+		KeyNames: DefaultRecordKeyNames,
+	}
+	logfmtFmt := LogfmtFormat()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		logfmtFmt.Format(r)
+	}
+}
+
+func BenchmarkLogfmtWithMixedCtx(b *testing.B) {
+	r := Record{
+		Time: time.Now(),
+		Lvl:  LvlInfo,
+		Msg:  "test message",
+		Ctx: []interface{}{
+			"int", 1,
+			"int64", int64(1),
+			"float", 3.0,
+			"string", "four!",
+			"bool", true,
+		},
+		KeyNames: DefaultRecordKeyNames,
+	}
+	logfmtFmt := LogfmtFormat()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		logfmtFmt.Format(r)
+	}
+}
+
+func BenchmarkTerminalFormatNoCtx(b *testing.B) {
+	r := Record{
+		Time:     time.Now(),
+		Lvl:      LvlInfo,
+		Msg:      "test message",
+		Ctx:      []interface{}{},
+		KeyNames: DefaultRecordKeyNames,
+	}
+	termFmt := TerminalFormat()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		termFmt.Format(r)
+	}
+}
+
+func BenchmarkTerminalFormatWithIntCtx(b *testing.B) {
+	r := Record{
+		Time:     time.Now(),
+		Lvl:      LvlInfo,
+		Msg:      "test message",
+		Ctx:      []interface{}{"count", 42, "size", int64(1024), "code", uint32(200)},
+		KeyNames: DefaultRecordKeyNames,
+	}
+	termFmt := TerminalFormat()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		termFmt.Format(r)
+	}
+}

--- a/v3/format.go
+++ b/v3/format.go
@@ -63,9 +63,23 @@ func TerminalFormat() Format {
 		b := &bytes.Buffer{}
 		lvl := strings.ToUpper(r.Lvl.String())
 		if color > 0 {
-			fmt.Fprintf(b, "\x1b[%dm%s\x1b[0m[%s] %s ", color, lvl, r.Time.Format(termTimeFormat), r.Msg)
+			b.WriteString("\x1b[")
+			b.WriteString(strconv.Itoa(color))
+			b.WriteString("m")
+			b.WriteString(lvl)
+			b.WriteString("\x1b[0m[")
+			b.WriteString(r.Time.Format(termTimeFormat))
+			b.WriteString("] ")
+			b.WriteString(r.Msg)
+			b.WriteByte(' ')
 		} else {
-			fmt.Fprintf(b, "[%s] [%s] %s ", lvl, r.Time.Format(termTimeFormat), r.Msg)
+			b.WriteByte('[')
+			b.WriteString(lvl)
+			b.WriteString("] [")
+			b.WriteString(r.Time.Format(termTimeFormat))
+			b.WriteString("] ")
+			b.WriteString(r.Msg)
+			b.WriteByte(' ')
 		}
 
 		// try to justify the log output for short messages
@@ -106,7 +120,12 @@ func logfmt(buf *bytes.Buffer, ctx []interface{}, color int) {
 
 		// XXX: we should probably check that all of your key bytes aren't invalid
 		if color > 0 {
-			fmt.Fprintf(buf, "\x1b[%dm%s\x1b[0m=%s", color, k, v)
+			buf.WriteString("\x1b[")
+			buf.WriteString(strconv.Itoa(color))
+			buf.WriteString("m")
+			buf.WriteString(k)
+			buf.WriteString("\x1b[0m=")
+			buf.WriteString(v)
 		} else {
 			buf.WriteString(k)
 			buf.WriteByte('=')
@@ -224,8 +243,26 @@ func formatLogfmtValue(value interface{}) string {
 		return strconv.FormatFloat(float64(v), floatFormat, 3, 64)
 	case float64:
 		return strconv.FormatFloat(v, floatFormat, 3, 64)
-	case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
-		return fmt.Sprintf("%d", value)
+	case int:
+		return strconv.Itoa(v)
+	case int8:
+		return strconv.FormatInt(int64(v), 10)
+	case int16:
+		return strconv.FormatInt(int64(v), 10)
+	case int32:
+		return strconv.FormatInt(int64(v), 10)
+	case int64:
+		return strconv.FormatInt(v, 10)
+	case uint:
+		return strconv.FormatUint(uint64(v), 10)
+	case uint8:
+		return strconv.FormatUint(uint64(v), 10)
+	case uint16:
+		return strconv.FormatUint(uint64(v), 10)
+	case uint32:
+		return strconv.FormatUint(uint64(v), 10)
+	case uint64:
+		return strconv.FormatUint(v, 10)
 	case string:
 		return escapeString(v)
 	default:


### PR DESCRIPTION
While working on a slog shim for log15, claude and I found some small performance improvements that look mostly straightforward.

 | Benchmark | Before ns/op | After ns/op | Δ ns | Before B/op | After B/op | Δ B | Before allocs | After allocs | Δ allocs |
  |---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
  | `LogfmtNoCtx` | 552 | 527 | -5% | 256 | 208 | -19% | 10 | 9 | -1 |
  | `LogfmtWithIntCtx` | 1099 | 886 | -19% | 624 | 572 | -8% | 16 | 14 | -2 |
  | `LogfmtWithMixedCtx` | 1093 | 931 | -15% | 646 | 597 | -8% | 13 | 12 | -1 |
  | `TerminalFormatNoCtx` | 443 | 235 | -47% | 184 | 88 | -52% | 7 | 3 | -4 |
  | `TerminalFormatWithIntCtx` | 1204 | 532 | -55% | 448 | 256 | -43% | 18 | 7 | -11 |
  | `Log15AddingFields` | 6899 | 6798 | -1% | 3806 | 3807 | ~0% | 47 | 47 | 0 |